### PR TITLE
Refactor category fetching and add fallback for failed API requests

### DIFF
--- a/db/index.js
+++ b/db/index.js
@@ -83,7 +83,7 @@ db.clearCategories = () =>
     });
   });
 
-db.saveCategories = categories =>
+db.updateCategories = categories =>
   db.clearCategories()
     .then(() => {
       const dbInserts = categories.map((category) => {
@@ -97,12 +97,12 @@ db.saveCategories = categories =>
               reject(err);
               connection.release();
             } else {
-              connection.query(queryString, (error, results) => {
+              connection.query(queryString, (error) => {
                 if (error) {
                   reject(error);
                   connection.release();
                 } else {
-                  resolve(results);
+                  resolve();
                   connection.release();
                 }
               });
@@ -113,6 +113,26 @@ db.saveCategories = categories =>
       return Promise.all(dbInserts);
     })
     .catch(console.error);
+
+db.getCategories = () =>
+  new Promise((resolve, reject) => {
+    pool.getConnection((err, connection) => {
+      if (err) {
+        reject(err);
+        connection.release();
+      } else {
+        connection.query('SELECT * FROM trivia_categories', (error, results) => {
+          if (error) {
+            reject(error);
+            connection.release();
+          } else {
+            resolve(results);
+            connection.release();
+          }
+        });
+      }
+    });
+  });
 
 /** exports a database connection object */
 module.exports = db;

--- a/helpers/openTriviaDb.js
+++ b/helpers/openTriviaDb.js
@@ -2,7 +2,7 @@ const request = require('request');
 const Promise = require('bluebird');
 const db = require('../db/index.js');
 
-const OPEN_TRIVIA_DB_URL = 'https://opentdb.com';
+const OPEN_TRIVIA_DB_URL = 'https://opentdb.comx';
 
 const openTriviaDB = {};
 
@@ -11,12 +11,13 @@ openTriviaDB.fetchCategories = () => {
   return new Promise((resolve, reject) => {
     request(url, (err, res, body) => {
       if (err) reject(err);
-      const categories = JSON.parse(body).trivia_categories;
-      db.saveCategories(categories)
-        .catch(console.error);
-      resolve(categories);
+      else resolve(JSON.parse(body).trivia_categories);
     });
-  });
+  })
+    .then(categories => db.updateCategories(categories))
+    .then(() => db.getCategories())
+    // if API request fails, try falling back to what was saved in DB
+    .catch(() => db.getCategories());
 };
 
 module.exports = openTriviaDB;

--- a/helpers/openTriviaDb.js
+++ b/helpers/openTriviaDb.js
@@ -2,7 +2,7 @@ const request = require('request');
 const Promise = require('bluebird');
 const db = require('../db/index.js');
 
-const OPEN_TRIVIA_DB_URL = 'https://opentdb.comx';
+const OPEN_TRIVIA_DB_URL = 'https://opentdb.com';
 
 const openTriviaDB = {};
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prop-types": "^15.6.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
+    "request": "^2.83.0",
     "socket.io": "^2.0.3",
     "socket.io-client": "^2.0.3",
     "supertest": "^3.0.0",


### PR DESCRIPTION
Update the openTriviaDB helper function to take care of saving and retrieving
categories from the DB to pass back to SocketServerInterface. The retrieval
from the database is consistent with how questions are handled. Also added the
fallback of retrieving categories from the database in case of failed API requests.